### PR TITLE
Fixed "Failed to initialize log file" on macOS

### DIFF
--- a/GUI/GuiMain.py
+++ b/GUI/GuiMain.py
@@ -342,7 +342,7 @@ if __name__ == "__main__":
         if sys.platform == "win32":
             logfile = pathlib.Path(os.environ["APPDATA"])
         elif sys.platform == "darwin" or sys.platform == "linux":
-            logfile = pathlib.Path("~")
+            logfile = pathlib.Path.home()
         else:
             logfile = homeDir
         logfile = logfile / "demucs-gui"


### PR DESCRIPTION
When running "python GuiMain.py" on macOS (at least on a M1 Mac on macOS 12.1 Monterey), "pathlib.Path('~')" doesn't seem to refer to the home folder, and the error "Failed to initialize log file" is shown. Replaced this with "pathlib.Path.home()", and this seems to have fixed the issue.